### PR TITLE
GitHub Actions: Deprecating save-state and set-output commands

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,11 +33,10 @@ jobs:
         run: |
           echo -e "\n[revanced-magisk-module repo]($GITHUB_SERVER_URL/j-hc/revanced-magisk-module)" >>build.log
           BUILD_LOG=$(cat build.log)
-          BUILD_LOG="${BUILD_LOG//'%'/'%25'}"
-          BUILD_LOG="${BUILD_LOG//$'\n'/'%0A'}"
-          BUILD_LOG="${BUILD_LOG//$'\r'/'%0D'}"
 
-          echo "BUILD_LOG=$BUILD_LOG" >> $GITHUB_OUTPUT
+          echo "BUILD_LOG<<EOF" >> $GITHUB_ENV
+          echo "$BUILD_LOG" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
 
           cd build
           yt_op=$(find . -maxdepth 1 -name "youtube-revanced-magisk-*.zip" -printf '%P')
@@ -53,7 +52,7 @@ jobs:
       - name: Upload modules to release
         uses: svenstaro/upload-release-action@v2
         with:
-          body: ${{ steps.get_output.outputs.BUILD_LOG }}
+          body: ${{ env.BUILD_LOG }}
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: ./build/*
           release_name: ${{ steps.get_output.outputs.RELEASE_NAME }}
@@ -78,21 +77,21 @@ jobs:
           }"
           }
           if [ -n "${{ steps.get_output.outputs.YT_OUTPUT }}" ]; then
-            YT_VER=$(echo "${{ steps.get_output.outputs.BUILD_LOG }}" | sed -n 's/.*YouTube version: \(.*\)/\1/p')
+            YT_VER=$(echo "${{ env.BUILD_LOG }}" | sed -n 's/.*YouTube version: \(.*\)/\1/p')
             YT_DLURL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/releases/download/${{ steps.next_ver_code.outputs.NEXT_VER_CODE}}/${{ steps.get_output.outputs.YT_OUTPUT }}"
             UPDATE_YT_JSON=$(get_update_json "$YT_VER" "${{ steps.next_ver_code.outputs.NEXT_VER_CODE}}" "$YT_DLURL" "$CHANGELOG_URL")
             echo "$UPDATE_YT_JSON" >yt-update.json
           fi
 
           if [ -n "${{ steps.get_output.outputs.MUSIC_OUTPUT_ARM64 }}" ]; then
-            MUSIC_VER=$(echo "${{ steps.get_output.outputs.BUILD_LOG }}" | sed -n 's/.*Music (arm64-v8a) version: \(.*\)/\1/p')
+            MUSIC_VER=$(echo "${{ env.BUILD_LOG }}" | sed -n 's/.*Music (arm64-v8a) version: \(.*\)/\1/p')
             MUSIC_ARM64_DLURL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/releases/download/${{ steps.next_ver_code.outputs.NEXT_VER_CODE}}/${{ steps.get_output.outputs.MUSIC_OUTPUT_ARM64 }}"
             UPDATE_MUSIC_ARM64_JSON=$(get_update_json "$MUSIC_VER" "${{ steps.next_ver_code.outputs.NEXT_VER_CODE }}" "$MUSIC_ARM64_DLURL" "$CHANGELOG_URL")
             echo "$UPDATE_MUSIC_ARM64_JSON" >music-update-arm64-v8a.json
           fi
 
           if [ -n "${{ steps.get_output.outputs.MUSIC_OUTPUT_ARM }}" ]; then
-            MUSIC_VER=$(echo "${{ steps.get_output.outputs.BUILD_LOG }}" | sed -n 's/.*Music (arm-v7a) version: \(.*\)/\1/p')
+            MUSIC_VER=$(echo "${{ env.BUILD_LOG }}" | sed -n 's/.*Music (arm-v7a) version: \(.*\)/\1/p')
             MUSIC_ARM_DLURL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/releases/download/${{ steps.next_ver_code.outputs.NEXT_VER_CODE}}/${{ steps.get_output.outputs.MUSIC_OUTPUT_ARM }}"
             UPDATE_MUSIC_ARM_JSON=$(get_update_json "$MUSIC_VER" "${{ steps.next_ver_code.outputs.NEXT_VER_CODE }}" "$MUSIC_ARM_DLURL" "$CHANGELOG_URL")
             echo "$UPDATE_MUSIC_ARM_JSON" >music-update-arm-v7a.json

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           TAG=$(git tag --sort=creatordate | tail -1)
           if [ -z "$TAG" ]; then TAG=0; fi
-          echo ::set-output name=NEXT_VER_CODE::$((TAG + 1))
+          echo "NEXT_VER_CODE=$((TAG + 1))" >> $GITHUB_OUTPUT
 
       - name: Build Modules/APKs
         run: ./build.sh build
@@ -37,18 +37,18 @@ jobs:
           BUILD_LOG="${BUILD_LOG//$'\n'/'%0A'}"
           BUILD_LOG="${BUILD_LOG//$'\r'/'%0D'}"
 
-          echo ::set-output name=BUILD_LOG::$BUILD_LOG
+          echo "BUILD_LOG=$BUILD_LOG" >> $GITHUB_OUTPUT
 
           cd build
           yt_op=$(find . -maxdepth 1 -name "youtube-revanced-magisk-*.zip" -printf '%P')
-          echo ::set-output name=YT_OUTPUT::$yt_op
+          echo "YT_OUTPUT=$yt_op" >> $GITHUB_OUTPUT
           if [ -z "$yt_op" ]; then
-            echo ::set-output name=RELEASE_NAME::"revanced"
+            echo "RELEASE_NAME="revanced"" >> $GITHUB_OUTPUT
           else
-            echo ::set-output name=RELEASE_NAME::$yt_op
+            echo "RELEASE_NAME=$yt_op" >> $GITHUB_OUTPUT
           fi
-          echo ::set-output name=MUSIC_OUTPUT_ARM64::$(find . -maxdepth 1 -name "music-revanced-magisk-*-arm64-v8a.zip" -printf '%P')
-          echo ::set-output name=MUSIC_OUTPUT_ARM::$(find . -maxdepth 1 -name "music-revanced-magisk-*-arm-v7a.zip" -printf '%P')
+          echo "MUSIC_OUTPUT_ARM64=$(find . -maxdepth 1 -name "music-revanced-magisk-*-arm64-v8a.zip" -printf '%P')" >> $GITHUB_OUTPUT
+          echo "MUSIC_OUTPUT_ARM=$(find . -maxdepth 1 -name "music-revanced-magisk-*-arm-v7a.zip" -printf '%P')" >> $GITHUB_OUTPUT
 
       - name: Upload modules to release
         uses: svenstaro/upload-release-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,13 +46,13 @@ jobs:
 
           if ! git checkout update; then
             echo "first time building!"
-            echo ::set-output name=SHOULD_BUILD::1
+            echo "SHOULD_BUILD=1" >> $GITHUB_OUTPUT
           elif is_patches_latest || is_youtube_latest; then
             echo "build!"
-            echo ::set-output name=SHOULD_BUILD::1
+            echo "SHOULD_BUILD=1" >> $GITHUB_OUTPUT
           else
             echo "dont build!"
-            echo ::set-output name=SHOULD_BUILD::0
+            echo "SHOULD_BUILD=0" >> $GITHUB_OUTPUT
           fi
 
     outputs:


### PR DESCRIPTION
This should get rid of the 
" check: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
"
 messages and conform to latest output changes.