### PR TITLE
feat: UpToDown version support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,11 @@ jobs:
           fi
           echo "MUSIC_OUTPUT_ARM64=$(find . -maxdepth 1 -name "music-revanced-magisk-*-arm64-v8a.zip" -printf '%P')" >> $GITHUB_OUTPUT
           echo "MUSIC_OUTPUT_ARM=$(find . -maxdepth 1 -name "music-revanced-magisk-*-arm-v7a.zip" -printf '%P')" >> $GITHUB_OUTPUT
+          echo "TW_OUTPUT=$(find . -maxdepth 1 -name "twitter-revanced-magisk-*.zip" -printf '%P')" >> $GITHUB_OUTPUT
+          echo "RDIT_OUTPUT=$(find . -maxdepth 1 -name "reddit-revanced-magisk-*.zip" -printf '%P')" >> $GITHUB_OUTPUT
+          echo "TT_OUTPUT=$(find . -maxdepth 1 -name "tiktok-revanced-magisk-*.zip" -printf '%P')" >> $GITHUB_OUTPUT
+          echo "SP_OUTPUT=$(find . -maxdepth 1 -name "spotify-revanced-magisk-*.zip" -printf '%P')" >> $GITHUB_OUTPUT
+          echo "WW_OUTPUT=$(find . -maxdepth 1 -name "warnwetter-revanced-magisk-*.zip" -printf '%P')" >> $GITHUB_OUTPUT
 
       - name: Upload modules to release
         uses: svenstaro/upload-release-action@v2
@@ -95,6 +100,36 @@ jobs:
             MUSIC_ARM_DLURL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/releases/download/${{ steps.next_ver_code.outputs.NEXT_VER_CODE }}/${{ steps.get_output.outputs.MUSIC_OUTPUT_ARM }}"
             UPDATE_MUSIC_ARM_JSON=$(get_update_json "$MUSIC_VER" "${{ steps.next_ver_code.outputs.NEXT_VER_CODE }}" "$MUSIC_ARM_DLURL" "$CHANGELOG_URL")
             echo "$UPDATE_MUSIC_ARM_JSON" >music-update-arm-v7a.json
+          fi
+          if [ -n "${{ steps.get_output.outputs.TW_OUTPUT }}" ]; then
+            TW_VER=$(echo "${{ env.BUILD_LOG }}" | sed -n 's/.*Twitter: \(.*\)/\1/p' | xargs)
+            TW_DLURL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/releases/download/${{ steps.next_ver_code.outputs.NEXT_VER_CODE }}/${{ steps.get_output.outputs.TW_OUTPUT }}"
+            UPDATE_TW_JSON=$(get_update_json "$TW_VER" "${{ steps.next_ver_code.outputs.NEXT_VER_CODE}}" "$TW_DLURL" "$CHANGELOG_URL")
+            echo "$UPDATE_TW_JSON" >tw-update.json
+          fi
+          if [ -n "${{ steps.get_output.outputs.RDIT_OUTPUT }}" ]; then
+            RDIT_VER=$(echo "${{ env.BUILD_LOG }}" | sed -n 's/.*Reddit: \(.*\)/\1/p' | xargs)
+            RDIT_DLURL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/releases/download/${{ steps.next_ver_code.outputs.NEXT_VER_CODE }}/${{ steps.get_output.outputs.RDIT_OUTPUT }}"
+            UPDATE_RDIT_JSON=$(get_update_json "$RDIT_VER" "${{ steps.next_ver_code.outputs.NEXT_VER_CODE}}" "$RDIT_DLURL" "$CHANGELOG_URL")
+            echo "$UPDATE_RDIT_JSON" >rdit-update.json
+          fi
+          if [ -n "${{ steps.get_output.outputs.TT_OUTPUT }}" ]; then
+            TT_VER=$(echo "${{ env.BUILD_LOG }}" | sed -n 's/.*TikTok: \(.*\)/\1/p' | xargs)
+            TT_DLURL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/releases/download/${{ steps.next_ver_code.outputs.NEXT_VER_CODE }}/${{ steps.get_output.outputs.TT_OUTPUT }}"
+            UPDATE_TT_JSON=$(get_update_json "$TT_VER" "${{ steps.next_ver_code.outputs.NEXT_VER_CODE}}" "$TT_DLURL" "$CHANGELOG_URL")
+            echo "$UPDATE_TT_JSON" tt-update.json
+          fi
+          if [ -n "${{ steps.get_output.outputs.SP_OUTPUT }}" ]; then
+            SP_VER=$(echo "${{ env.BUILD_LOG }}" | sed -n 's/.*Spotify: \(.*\)/\1/p' | xargs)
+            SP_DLURL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/releases/download/${{ steps.next_ver_code.outputs.NEXT_VER_CODE }}/${{ steps.get_output.outputs.SP_OUTPUT }}"
+            UPDATE_SP_JSON=$(get_update_json "$SP_VER" "${{ steps.next_ver_code.outputs.NEXT_VER_CODE}}" "$SP_DLURL" "$CHANGELOG_URL")
+            echo "$UPDATE_SP_JSON" >sp-update.json
+          fi
+          if [ -n "${{ steps.get_output.outputs.WW_OUTPUT }}" ]; then
+            WW_VER=$(echo "${{ env.BUILD_LOG }}" | sed -n 's/.*WarnWetter: \(.*\)/\1/p' | xargs)
+            WW_DLURL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/releases/download/${{ steps.next_ver_code.outputs.NEXT_VER_CODE }}/${{ steps.get_output.outputs.WW_OUTPUT }}"
+            UPDATE_WW_JSON=$(get_update_json "$WW_VER" "${{ steps.next_ver_code.outputs.NEXT_VER_CODE}}" "$WW_DLURL" "$CHANGELOG_URL")
+            echo "$UPDATE_WW_JSON" >ww-update.json
           fi
           if [ ! -f *.json ]; then : >dummy.json; fi
 

--- a/build.sh
+++ b/build.sh
@@ -51,6 +51,11 @@ if [ "$BUILD_MINDETACH_MODULE" = true ]; then
 	cd mindetach-magisk/mindetach/
 	: >detach.txt
 	if [ "${YOUTUBE_MODE%/*}" != none ]; then echo "com.google.android.youtube" >>detach.txt; fi
+	if [ "${TWITTER_MODE%/*}" != none ]; then echo "com.twitter.android" >>detach.txt; fi
+	if [ "${REDDIT_MODE%/*}" != none ]; then echo "com.reddit.frontpage" >>detach.txt; fi
+	if [ "${TIKTOK_MODE%/*}" != none ]; then echo "com.zhiliaoapp.musically" >>detach.txt; fi
+	if [ "${SPOTIFY_MODE%/*}" != none ]; then echo "com.spotify.music" >>detach.txt; fi
+	if [ "${WARN_WETTER_MODE%/*}" != none ]; then echo "de.dwd.warnapp" >>detach.txt; fi
 	if [ "${MUSIC_ARM64_V8A_MODE%/*}" != none ] || [ "${MUSIC_ARM_V7A_MODE%/*}" != none ]; then
 		echo "com.google.android.apps.youtube.music" >>detach.txt
 	fi

--- a/utils.sh
+++ b/utils.sh
@@ -347,7 +347,7 @@ build_reddit() {
 	declare -A reddit_args
 	reddit_args[app_name]="Reddit"
 	reddit_args[mode]="$REDDIT_MODE"
-	reddit_args[pkg_name]="om.reddit.frontpage"
+	reddit_args[pkg_name]="com.reddit.frontpage"
 	reddit_args[apkmirror_dlurl]="redditinc/reddit/reddit"
 	reddit_args[regexp]='APK</span>[^@]*@\([^#]*\)'
 	reddit_args[module_prop_name]="rditrv-magisk"
@@ -365,7 +365,7 @@ build_tiktok() {
 	tiktok_args[pkg_name]="com.zhiliaoapp.musically"
 	tiktok_args[apkmirror_dlurl]="tiktok-pte-ltd/tik-tok-including-musical-ly/tik-tok-including-musical-ly"
 	tiktok_args[regexp]='APK</span>[^@]*@\([^#]*\)'
-	tiktok_args[module_prop_name]="tt-magisk"
+	tiktok_args[module_prop_name]="ttrv-magisk"
 	#shellcheck disable=SC2034
 	tiktok_args[module_update_json]="tt-update.json"
 
@@ -378,7 +378,7 @@ build_spotify() {
 	spotify_args[mode]="$SPOTIFY_MODE"
 	spotify_args[pkg_name]="com.spotify.music"
 	spotify_args[uptodown_dlurl]="https://spotify.en.uptodown.com/android/apps/16806/versions"
-	spotify_args[module_prop_name]="sp-magisk"
+	spotify_args[module_prop_name]="sprv-magisk"
 	#shellcheck disable=SC2034
 	spotify_args[module_update_json]="sp-update.json"
 
@@ -392,7 +392,7 @@ build_warn_wetter() {
 	warn_wetter_args[pkg_name]="de.dwd.warnapp"
 	warn_wetter_args[apkmirror_dlurl]="deutscher-wetterdienst/warnwetter/warnwetter"
 	warn_wetter_args[regexp]='APK</span>[^@]*@\([^#]*\)'
-	warn_wetter_args[module_prop_name]="ww-magisk"
+	warn_wetter_args[module_prop_name]="wwrv-magisk"
 	#shellcheck disable=SC2034
 	warn_wetter_args[module_update_json]="ww-update.json"
 

--- a/utils.sh
+++ b/utils.sh
@@ -242,10 +242,14 @@ build_rv() {
 			fi
 		fi
 
-		if [ "${args[arch]}" = "all" ]; then
-			log "${args[app_name]}: ${version}"
+		if ! grep -q -e "${args[app_name]}: ${version}" -e "${args[app_name]} (${args[arch]}): ${version}" build.md; then
+			if [ "${args[arch]}" = "all" ]; then
+				log "${args[app_name]}: ${version}"
+			else
+				log "${args[app_name]} (${args[arch]}): ${version}"
+			fi
 		else
-			log "${args[app_name]} (${args[arch]}): ${version}"
+			echo "Duplicate Entry found in build.md"
 		fi
 
 		if [ ! -f "$patched_apk" ] || [ "${args[microg_patch]:-}" ]; then


### PR DESCRIPTION
In this PR you will be able to tell the conf what version you want for the app and "auto" retrieves latest from patches if more uptodown apps are added in the future while latest continues to function as before. 

Also I fixed a typo and added magisk update support that wasn't there.

Also made the mindetach work on all apps if modules are used.

I also noticed when running "both" the build.md got duplicates, so I added a check function to skip when it already exist.