### PR TITLE
Change revanced-patches repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You can get the [latest CI release from here](https://github.com/j-hc/revanced-m
 #### **Note that the [CI workflow](../../actions/workflows/ci.yml) is scheduled to build the modules and APKs everyday if there is a change. You may want to disable it.**
 
 ## To include/exclude patches
-[**See the list of patches**](https://github.com/revanced/revanced-patches#-list-of-available-patches)
+[**See the list of patches**](https://github.com/PalmDevs/rvp#-patches)
 
  * Star the repo :eyes:
  * [Fork the repo](https://github.com/j-hc/revanced-magisk-module/fork) or use it as a template

--- a/build.conf
+++ b/build.conf
@@ -22,7 +22,7 @@ MUSIC_ARM_V7A_MODE=both/auto
 TWITTER_MODE=apk/latest
 REDDIT_MODE=apk/latest
 TWITCH_MODE=apk/latest
-TIKTOK_MODE=apk/27.0.3
+TIKTOK_MODE=apk/latest
 
 SPOTIFY_MODE=none/latest # patches for spotify are quite useless tbh
 TICKTICK_MODE=none/latest

--- a/utils.sh
+++ b/utils.sh
@@ -9,7 +9,7 @@ BUILD_DIR="build"
 
 GITHUB_REPOSITORY=${GITHUB_REPOSITORY:-$"j-hc/revanced-magisk-module"}
 NEXT_VER_CODE=${NEXT_VER_CODE:-$(date +'%Y%m%d')}
-WGET_HEADER="User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:106.0) Gecko/20100101 Firefox/106.0"
+WGET_HEADER="User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:107.0) Gecko/20100101 Firefox/107.0"
 
 SERVICE_SH=$(cat $MODULE_SCRIPTS_DIR/service.sh)
 POSTFSDATA_SH=$(cat $MODULE_SCRIPTS_DIR/post-fs-data.sh)
@@ -32,7 +32,7 @@ get_prebuilts() {
 	log "Integrations: $RV_INTEGRATIONS_APK"
 	RV_INTEGRATIONS_APK="${TEMP_DIR}/${RV_INTEGRATIONS_APK}"
 
-	RV_PATCHES=$(req https://api.github.com/repos/revanced/revanced-patches/releases/latest -)
+	RV_PATCHES=$(req https://api.github.com/repos/PalmDevs/rvp/releases/latest -)
 	RV_PATCHES_CHANGELOG=$(echo "$RV_PATCHES" | json_get 'body' | sed 's/\(\\n\)\+/\\n/g')
 	RV_PATCHES_URL=$(echo "$RV_PATCHES" | json_get 'browser_download_url' 'jar')
 	RV_PATCHES_JAR="${TEMP_DIR}/${RV_PATCHES_URL##*/}"


### PR DESCRIPTION
Since the official repo got DCMA, I think changing to a mirror temporary would be good to prevent new forks/templates not working.

Also this mirror is created by someone at ReVanced team (Palm) and is being advertised by the team itself on [Discord](https://discord.com/channels/952946952348270622/952946952348270626/1050622798118256721) and [Telegram](https://t.me/revanced_discussion/3192/30352) so it's trustful.

(the other little changes are just changing the README.md to include new link to see the available patches, makes build tiktok in latest version again and bump firefox user agent)