### PR TITLE
Fix release title when building ReVanced Extended

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
           cp -f build.md build.tmp
 
           cd build
-          yt_op=$(find . -maxdepth 1 -name "youtube-revanced-magisk-*.zip" -printf '%P')
+          yt_op=$(find . -maxdepth 1 -name "youtube-revanced-*.zip" -printf '%P')
           if [ -z "$yt_op" ]; then
             echo "RELEASE_NAME=ReVanced" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
When building using revanced extended, release name will default to "ReVanced".
This happens because new build method renames the magisk zip files to "youtube-revanced-extended-magisk- {version}.zip" instead of "youtube-revanced-magisk- {version}.zip" when using revanced-extended.
The solution is to just check for the zip file starting with "youtube-revanced" in build.yml, which covers both build cases.