### PR TITLE
Download APK Direct URLS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,9 @@ jobs:
         with:
           fetch-depth: 0
           submodules: true
+        
+      - name: Install aapt (for APK metadata extraction)
+        run: sudo apt update && sudo apt install aapt
 
       - name: Get last tag
         id: last_tag

--- a/build.sh
+++ b/build.sh
@@ -75,6 +75,12 @@ for table_name in $(toml_get_table_names); do
 			abort "ERROR: build-mode '${app_args[build_mode]}' is not a valid option for '${table_name}': only 'both', 'apk' or 'module' is allowed"
 		fi
 	} || app_args[build_mode]=apk
+	app_args[direct_dlurl]=$(toml_get "$t" direct-dlurl) && {
+		app_args[direct_dlurl]=${app_args[direct_dlurl]%/}
+		app_args[direct_dlurl]=${app_args[direct_dlurl]%download}
+		app_args[direct_dlurl]=${app_args[direct_dlurl]%/}
+		app_args[dl_from]=direct
+	} || app_args[uptodown_dlurl]=""
 	app_args[uptodown_dlurl]=$(toml_get "$t" uptodown-dlurl) && {
 		app_args[uptodown_dlurl]=${app_args[uptodown_dlurl]%/}
 		app_args[uptodown_dlurl]=${app_args[uptodown_dlurl]%download}


### PR DESCRIPTION
Since APKMonk now blacklists GitHub Actions with Cloudlfare, I needed somehting else to download Photomath.

This approach requires aapt for metadata extraction, so it's not as clean as your previous work. *EDIT: I'm OK if you don'T want to merge it that way. Or meniton it in the readme? Or, honestly, I didn't really look into how I could extarct the needed data without aapt, and I'm relaly tired, I'll go to sleep.*

You can see a test run [here](https://github.com/Smart123s/revanced-extended-autobuild/actions/runs/4611663881/jobs/8151622287) on my personal fork at https://github.com/Smart123s/revanced-extended-autobuild/commit/61789b7c2c28cdeeb2128e6182b4ce78360b4a6d.

I've downloaded a Photomath APK form APKMonk, and uploaded it to archive.org ([link](https://archive.org/details/com.microblink.photomath-8.20.0-all))