### PR TITLE
Disable web page preview on Telegram

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,7 +132,7 @@ jobs:
           "
           echo "'$MSG'"
           POST="https://api.telegram.org/bot${TG_TOKEN}/sendMessage"
-          curl -X POST --data-urlencode "parse_mode=Markdown" --data-urlencode "text=${MSG}" --data-urlencode "chat_id=${TG_CHAT}" "$POST"
+          curl -X POST --data-urlencode "parse_mode=Markdown" --data-urlencode "disable_web_page_preview=true" --data-urlencode "text=${MSG}" --data-urlencode "chat_id=${TG_CHAT}" "$POST"
 
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
The `disable_web_page_preview` parameter in the Telegram Bot API can be used to disable the web page preview for a message. This prevents the Telegram app from displaying a preview of the link in the message.