### PR TITLE
fix dl_uptodown()

### DIFF
--- a/utils.sh
+++ b/utils.sh
@@ -382,7 +382,7 @@ dl_uptodown() {
 	data_code=$($HTMLQ "#detail-app-name" --attribute data-code <<<"$__UPTODOWN_RESP__")
 	local versionURL=""
 	local is_bundle=false
-	for i in {1..5}; do
+	for i in {1..9}; do
 		resp=$(req "${uptodown_dlurl}/apps/${data_code}/versions/${i}" -)
 		if ! op=$(jq -e -r ".data | map(select(.version == \"${version}\")) | .[0]" <<<"$resp"); then
 			continue


### PR DESCRIPTION
Searching for required `version` string only in 5 pages is not enough. So users are still unable to download Meta's apps apks.