### PR TITLE
Skip to the next mirror when 403 error occurs

### DIFF
--- a/utils.sh
+++ b/utils.sh
@@ -360,7 +360,7 @@ get_apkmirror_vers() {
 }
 get_apkmirror_pkg_name() { sed -n 's;.*id=\(.*\)" class="accent_color.*;\1;p' <<<"$__APKMIRROR_RESP__"; }
 get_apkmirror_resp() {
-	__APKMIRROR_RESP__=$(req "${1}" -)
+	__APKMIRROR_RESP__=$(req "${1}" -) || return 1
 	__APKMIRROR_CAT__="${1##*/}"
 }
 


### PR DESCRIPTION
When the Cloudflare protection triggers, the curl in __APKMIRROR_RESP__ receives a 403 error. However, the function doesn't exit imediately, as a result, the last function exit code is the __APKMIRROR_CAT__ call that can pass. In this situation, even if our mirror failed, the code skips all other mirrors and exit imediately since the pkg_name is not available.

The current modification makes sure that the function exits imediately after the error, allowing us to move to the next mirror (uptodown) instead of skipping the entire package build.

```
 get_apkmirror_resp() {
-       __APKMIRROR_RESP__=$(req "${1}" -)
+       __APKMIRROR_RESP__=$(req "${1}" -) || return 1
        __APKMIRROR_CAT__="${1##*/}"
 }
```