### PR TITLE
Fix error message if the application is not found in the patches list

### DIFF
--- a/utils.sh
+++ b/utils.sh
@@ -249,13 +249,13 @@ get_patch_last_supported_ver() {
 			return
 		fi
 	fi
-	if ! op=$(java -jar "$rv_cli_jar" list-versions "$rv_patches_jar" -f "$pkg_name" 2>&1 | tail -n +3 | awk '{$1=$1}1'); then
-		epr "list-versions: '$op'"
-		return 1
-	fi
+	op=$(java -jar "$rv_cli_jar" list-versions "$rv_patches_jar" -f "$pkg_name" 2>&1 | tail -n +3 | awk '{$1=$1}1')
 	if [ "$op" = "Any" ]; then return; fi
 	pcount=$(head -1 <<<"$op") pcount=${pcount#*(} pcount=${pcount% *}
-	if [ -z "$pcount" ]; then abort "unreachable: '$pcount'"; fi
+	if [ -z "$pcount" ]; then
+		av_apps=$(java -jar "$rv_cli_jar" list-versions "$rv_patches_jar" 2>&1 | awk '/Package name:/ { printf "%s\x27%s\x27", sep, $NF; sep=", " } END { print "" }')
+		abort "No patch versions found for '$pkg_name' in this patches source!\nAvailable applications found: $av_apps";
+	fi
 	grep -F "($pcount patch" <<<"$op" | sed 's/ (.* patch.*//' | get_highest_ver || return 1
 }
 


### PR DESCRIPTION
The current error message was always displaying an empty variable without telling what could be the potential issue.
The proposed reimplementation tells exactly what the error is and shows what applications are supported in the selected patches source. This opens the path to support different patches sources that contain different applcation lists, like Morphe.

Example output for Morphe patch source when trying to build Facebook: 
```
[-] ABORT: No patch versions found for 'com.facebook.katana' in this patches source!
Available applications found: 'com.google.android.apps.youtube.music', 'com.google.android.youtube'
```

This change also removes the dead code around the op assignment since in it's current implementation, that code would never execute. Additionally the op value check was also done in the code sequence that was modified to correctly display the error message.