### PR TITLE
Check and warn about the asset number

### DIFF
--- a/utils.sh
+++ b/utils.sh
@@ -90,7 +90,11 @@ get_prebuilts() {
 			local resp asset name
 			resp=$(gh_req "$rv_rel" -) || return 1
 			tag_name=$(jq -r '.tag_name' <<<"$resp")
-			asset=$(jq -e -r ".assets[] | select(.name | endswith(\"$ext\"))" <<<"$resp") || return 1
+			matches=$(jq -e ".assets | map(select(.name | endswith(\"$ext\")))" <<<"$resp")
+			if [ "$(jq 'length' <<<"$matches")" -ne 1 ]; then
+				epr "More than 1 asset was found for this cli release. Fallbacking to the first one found..."
+			fi
+			asset=$(jq -r ".[0]" <<<"$matches")
 			url=$(jq -r .url <<<"$asset")
 			name=$(jq -r .name <<<"$asset")
 			file="${dir}/${name}"


### PR DESCRIPTION
The code despite allowing multiple assets to exits, it was designed so that only 1 is expected for a release. This assumption held true, until some releases like the Morphe's 1.1.0 release where they incorrectly added 2 jars:
https://github.com/MorpheApp/morphe-cli/releases/tag/v1.1.0-dev.1

Since this is not expected (considering the fact that one of those jars is named incorrectly), it's fair to assume that it's not the indended way they want to do releases from now on and that we should warn about these incorrect releases, even if we continue the execution with the first found artifact.