### PR TITLE
Customize the author's name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ test*
 /logs
 build.md
 cmpr
+revanced-magisk/maintainer.txt

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -16,6 +16,8 @@ There exists an example below with all defaults shown and all the keys explicitl
 **All keys are optional** (except download urls) and are assigned to their default values if not set explicitly.  
 
 ```toml
+author = "j-hc"                      # change the module author's name. default: "j-hc"
+author-page = "github.com/j-hc"      # change the module author's profile page. default: "github.com/j-hc"
 parallel-jobs = 1                    # amount of cores to use for parallel patching, if not set $(nproc) is used
 compression-level = 9                # module zip compression level
 remove-rv-integrations-checks = true # remove checks from the revanced integrations

--- a/build.sh
+++ b/build.sh
@@ -27,6 +27,8 @@ if ! PARALLEL_JOBS=$(toml_get "$main_config_t" parallel-jobs); then
 	if [ "$OS" = Android ]; then PARALLEL_JOBS=1; else PARALLEL_JOBS=$(nproc); fi
 fi
 REMOVE_RV_INTEGRATIONS_CHECKS=$(toml_get "$main_config_t" remove-rv-integrations-checks) || REMOVE_RV_INTEGRATIONS_CHECKS="true"
+DEF_AUTHOR_NAME=$(toml_get "$main_config_t" author) || DEF_AUTHOR_NAME="j-hc"
+DEF_AUTHOR_PAGE=$(toml_get "$main_config_t" author-page) || DEF_AUTHOR_PAGE="github.com/j-hc"
 DEF_PATCHES_VER=$(toml_get "$main_config_t" patches-version) || DEF_PATCHES_VER="latest"
 DEF_CLI_VER=$(toml_get "$main_config_t" cli-version) || DEF_CLI_VER="latest"
 DEF_PATCHES_SRC=$(toml_get "$main_config_t" patches-source) || DEF_PATCHES_SRC="ReVanced/revanced-patches"
@@ -52,6 +54,8 @@ rm -rf revanced-magisk/bin/*/tmp.*
 if [ "$(echo "$TEMP_DIR"/*-rv/changelog.md)" ]; then
 	: >"$TEMP_DIR"/*-rv/changelog.md || :
 fi
+
+echo "${DEF_AUTHOR_NAME}${DEF_AUTHOR_PAGE:+ ($DEF_AUTHOR_PAGE)}" > "revanced-magisk/maintainer.txt"
 
 mkdir -p ${MODULE_TEMPLATE_DIR}/bin/arm64 ${MODULE_TEMPLATE_DIR}/bin/arm ${MODULE_TEMPLATE_DIR}/bin/x86 ${MODULE_TEMPLATE_DIR}/bin/x64
 gh_dl "${MODULE_TEMPLATE_DIR}/bin/arm64/cmpr" "https://github.com/j-hc/cmpr/releases/latest/download/cmpr-arm64-v8a"

--- a/revanced-magisk/customize.sh
+++ b/revanced-magisk/customize.sh
@@ -175,6 +175,10 @@ nohup cmd package compile --reset "$PKG_NAME" >/dev/null 2>&1 &
 
 rm -rf "${MODPATH:?}/bin" "$MODPATH/$PKG_NAME.apk"
 
+MAINTAINER_FILE="$MODPATH/maintainer.txt"
+if [ -f "$MAINTAINER_FILE" ]; then MAINTAINER=$(cat "$MAINTAINER_FILE"); fi
+if [ -z "$MAINTAINER" ]; then MAINTAINER="j-hc (github.com/j-hc)"; fi
+
 ui_print "* Done"
-ui_print "  by j-hc (github.com/j-hc)"
+ui_print "  by $MAINTAINER"
 ui_print " "

--- a/utils.sh
+++ b/utils.sh
@@ -626,6 +626,7 @@ build_rv() {
 			"${args[module_prop_name]}" \
 			"${app_name} ${args[rv_brand]}" \
 			"${version} (patches ${rv_patches_ver%%.rvp})" \
+			"${DEF_AUTHOR_NAME}" \
 			"${app_name} ${args[rv_brand]} Magisk module" \
 			"https://raw.githubusercontent.com/${GITHUB_REPOSITORY-}/update/${upj}" \
 			"$base_template"
@@ -660,8 +661,8 @@ module_prop() {
 name=${2}
 version=v${3}
 versionCode=${NEXT_VER_CODE}
-author=j-hc
-description=${4}" >"${6}/module.prop"
+author=${4}
+description=${5}" >"${7}/module.prop"
 
-	if [ "$ENABLE_MAGISK_UPDATE" = true ]; then echo "updateJson=${5}" >>"${6}/module.prop"; fi
+	if [ "$ENABLE_MAGISK_UPDATE" = true ]; then echo "updateJson=${6}" >>"${7}/module.prop"; fi
 }


### PR DESCRIPTION
The change allows the developer to customize the author's name so that forks are able to correctly differentiate what applications are built by them and not by upstream without modifying the source code.

By correctly tagging their build, you can reduce the number of issues falsly reported upstream.