### PR TITLE
Redirect GitHub error to stderr in epr()

### DIFF
--- a/utils.sh
+++ b/utils.sh
@@ -39,7 +39,7 @@ toml_get() {
 pr() { echo -e "\033[0;32m[+] ${1}\033[0m"; }
 epr() {
 	echo >&2 -e "\033[0;31m[-] ${1}\033[0m"
-	if [ "${GITHUB_REPOSITORY-}" ]; then echo -e "::error::utils.sh [-] ${1}\n"; fi
+	if [ "${GITHUB_REPOSITORY-}" ]; then echo >&2 -e "::error::utils.sh [-] ${1}\n"; fi
 }
 abort() {
 	epr "ABORT: ${1-}"


### PR DESCRIPTION
The current implementation was sending the error to the stdout output. This would making the situation when 2 tar artifacts were found fatal. The error message was sent to stdout (while it was executed in Github) and it was used as the return for the get_rv_prebuilts function.

This was not the intended behavior and this change fixes this bug.