### PR TITLE
feat: filter selective builds by patches source or owner names

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,8 +9,16 @@ on:
 
   workflow_dispatch:
     inputs:
-      patches_source:
-        description: "Enter patches source or owner names separated by spaces. Leave empty to build all"
+      filter_type:
+        description: "Select filter type"
+        required: true
+        type: choice
+        options:
+          - patches
+          - app
+        default: "patches"
+      filter_value:
+        description: "Enter patches owner or app names separated by spaces. Leave empty to build all"
         required: false
         type: string
         default: ""
@@ -32,10 +40,10 @@ jobs:
           submodules: true
 
       - name: Update config
-        if: ${{ inputs.from_ci || inputs.patches_source != '' }}
+        if: ${{ inputs.from_ci || inputs.filter_value != '' }}
         run: |
           if git show origin/update:build.md > build.md; then
-            UPDATE_CFG=$(./build.sh config.toml --config-update "${{ inputs.patches_source }}")
+            UPDATE_CFG=$(./build.sh config.toml --config-update "${{ inputs.filter_type }}" "${{ inputs.filter_value }}")
             if [ "$UPDATE_CFG" ]; then
               echo "$UPDATE_CFG" > config.json
             fi

--- a/build.sh
+++ b/build.sh
@@ -36,10 +36,10 @@ DEF_DPI_LIST=$(toml_get "$main_config_t" dpi) || DEF_DPI_LIST="nodpi anydpi"
 mkdir -p "$TEMP_DIR" "$BUILD_DIR"
 
 if [ "${2-}" = "--config-update" ]; then
-	config_update "${3-}"
+	config_update "${3-patches}" "${4-}"
 	exit 0
 elif [ -n "${2-}" ]; then
-	config_update "${2}" > config.json
+	config_update "${2-patches}" "${3-}" > config.json
 	exec ./build.sh config.json
 fi
 
@@ -174,7 +174,8 @@ log "Use [zygisk-detach](https://github.com/j-hc/zygisk-detach) to detach root R
 log "\n[revanced-magisk-module](https://github.com/j-hc/revanced-magisk-module)\n"
 log "$(cat "$TEMP_DIR"/*/changelog.md)"
 
-SKIPPED=$(cat "$TEMP_DIR"/skipped 2>/dev/null || :)
+CHANGELOGS=$(cat "$TEMP_DIR"/*/changelog.md 2>/dev/null || :)
+SKIPPED=$(grep -vFf <(echo "$CHANGELOGS") "$TEMP_DIR"/skipped 2>/dev/null || :)
 if [ -n "$SKIPPED" ]; then
 	log "\nSkipped:"
 	log "$SKIPPED"


### PR DESCRIPTION
feat: add selective filtering by app/patches and improve build handling

Usage: `./build.sh config.toml <patches|app> "value1 value2"`

- Support filtering by app names or patches owners separated by spaces. Leave empty to build all
Example: `./build.sh config.toml patches "anddea morpheapp"`
- Remove hardcoded ReVanced brand constraints
- Improve skipped filtering: exclude already-built apps from changelog
- This fixes build failures for apps with special characters in their version strings.
Example: 
Icon-Pack-Studio: 2.2 build 016
Nova-Launcher: 81023 (8.3.1)
