### PR TITLE
Improve error handling in bash scripts

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -uo pipefail
 shopt -s nullglob
 trap "rm -rf temp/*tmp.* temp/*/*tmp.* temp/*-temporary-files; exit 130" INT
 
@@ -151,9 +151,9 @@ for table_name in $(toml_get_table_names); do
 		build_rv "$(declare -p app_args)" &
 	fi
 done
-wait
+wait || true
 rm -rf temp/tmp.*
-if [ -z "$(ls -A1 "${BUILD_DIR}")" ]; then abort "All builds failed."; fi
+if [ -z "$(ls -A1 "${BUILD_DIR}" 2>/dev/null)" ]; then abort "All builds failed."; fi
 
 log "\nInstall [Microg](https://github.com/ReVanced/GmsCore/releases) for non-root YouTube and YT Music APKs"
 log "Use [zygisk-detach](https://github.com/j-hc/zygisk-detach) to detach YouTube and YT Music modules from Play Store"


### PR DESCRIPTION
Refactored build.sh and utils.sh to handle errors more gracefully, allowing builds to continue when individual app builds fail. Enhanced error reporting for APKMirror, Uptodown, and archive requests, and updated build_rv to avoid aborting on patch version failures. These changes improve robustness and provide clearer diagnostics during batch operations.